### PR TITLE
fix(mesh):repair vertex holes at head model crown

### DIFF
--- a/configs/6views.yaml
+++ b/configs/6views.yaml
@@ -12,7 +12,7 @@ far: 10.0
 views: [0, -90, 180, 90, -45, 45]
 # ========= Geo Optimization =========
 vis_interval: 100
-uv_interpolate: True  
+uv_interpolate: False  
 uv_tex: 'mix'  # 'flame' or 'xatlax' or 'mix'
 no_remesh: False
 no_lmk_loss: False 

--- a/src/geo/mesh_opt.py
+++ b/src/geo/mesh_opt.py
@@ -70,6 +70,20 @@ def remesh_withuv(
     ):
     from .remesh_uv import calc_edge_length, calc_edges, calc_face_collapses, calc_face_normals, calc_vertex_normals, collapse_edges, flip_edges, pack, prepend_dummies, remove_dummies, split_edges
 
+    if vt is not None and ft is not None:
+        if vt.shape[0] != vertices_etc.shape[0]:
+            new_vt = torch.zeros((vertices_etc.shape[0], vt.shape[1]), dtype=vt.dtype, device=vt.device)
+            vertex_has_uv = torch.zeros(vertices_etc.shape[0], dtype=torch.bool, device=vertices_etc.device)  
+            for i, (f, ft_idx) in enumerate(zip(faces, ft)):
+                for j in range(3):
+                    v_idx = f[j]
+                    vt_idx = ft_idx[j]
+                    if not vertex_has_uv[v_idx]:
+                        new_vt[v_idx] = vt[vt_idx]
+                        vertex_has_uv[v_idx] = True
+            vt = new_vt
+            ft = faces.clone()  
+
     # dummies
     vertices_etc,faces = prepend_dummies(vertices_etc,faces)
     if vt is not None:

--- a/src/utils/mesh.py
+++ b/src/utils/mesh.py
@@ -30,6 +30,7 @@ def split_mesh(mesh: Mesh,  v_mask: torch.Tensor):
     Returns:
     - (vertices1, faces1), (vertices2, faces2): Tuple of two split meshes.
     """ 
+    
     # Create masks for vertex ownership
     is_in_mesh1 = v_mask.bool()  
     is_in_mesh2 = ~is_in_mesh1  # The rest belong to the second mesh


### PR DESCRIPTION
## Title: Fix: repair vertex holes at head model crown

**Changes:**
*  Merged remesh and remesh_withuv into a single function. When uv_interpolate is set to False, there are no UV seam issues and the mesh crown no longer breaks
*  Added self.only_face_vid and updated its indices after remeshing
*  Modified face_mask before split_mesh in uv_texture, using self.only_face_vid to obtain face_mask, resolving UV adhesion issues caused by remesh_withuv when uv_interpolate=False


**Results：**
**Before optimization**
<img width="888" height="532" alt="屏幕截图 2025-07-21 150931" src="https://github.com/user-attachments/assets/babd4f14-8181-4918-ae0d-99a41a54ba2a" />
**After optimization**
<img width="889" height="535" alt="屏幕截图 2025-07-21 151002" src="https://github.com/user-attachments/assets/67b6ad13-db32-4057-a473-036b7b7509a5" />

